### PR TITLE
Use tagged release image for raiden-services

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ or contact us via email at contact@raiden.nework.
 
 ## Changelog
 
+- 2019-10-07 - `2019.10.1` - **Upgrade release**
+  - Upgrade https://github.com/raiden-network/raiden-services image to `v0.4.0`
 - 2019-10-02 - `2019.10.0` - **Upgrade release**
   - Add https://github.com/raiden-network/raiden-services services to the bundle
   - Upgrade Synapse to v1.3.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 
 x-defaults: &defaults
-  image: raidennetwork/raiden-services
+  image: raidennetwork/raiden-services:v0.4.0
   env_file: .env
   volumes:
     - ${DATA_DIR:-./data}/state:/state


### PR DESCRIPTION
This changes the compose recipe to use the latest tagged release image for `raidennetwork/raiden-services`.